### PR TITLE
Minor improvements

### DIFF
--- a/DownloadToGo.podspec
+++ b/DownloadToGo.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   
   s.name             = 'DownloadToGo'
-  s.version          = '3.0.0'
+  s.version          = '3.0.2'
   s.summary          = 'DownloadToGo -- download manager for HLS'
   s.homepage         = 'https://github.com/kaltura/DownloadToGo'
   s.license          = { :type => 'AGPLv3', :file => 'LICENSE' }

--- a/Example/DownloadToGo.xcodeproj/project.pbxproj
+++ b/Example/DownloadToGo.xcodeproj/project.pbxproj
@@ -344,7 +344,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		8669368EA60E351E6844A10D /* [CP] Copy Pods Resources */ = {
@@ -374,7 +374,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Example/DownloadToGo/AppDelegate.swift
+++ b/Example/DownloadToGo/AppDelegate.swift
@@ -23,8 +23,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             print("server started")
         }
         
-        try? ContentManager.shared.resumeInterruptedItems()
-        
+        // resume all interrupted downloads that were stopped in progress
+        try? ContentManager.shared.startItems(inStates: .inProgress)
         return true
     }
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - DownloadToGo (3.0.0.rc3):
+  - DownloadToGo (3.0.2):
     - GCDWebServer (~> 3.3.3)
     - M3U8Kit (= 0.2.1)
     - RealmSwift (= 2.8.3)
@@ -47,10 +47,10 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   DownloadToGo:
-    :path: ..
+    :path: ".."
 
 SPEC CHECKSUMS:
-  DownloadToGo: cda37746320d40521d569b1c1c8a929f804755eb
+  DownloadToGo: 18bf343a55f60adbff66fababbf4d7554fb4d1b6
   GCDWebServer: 1c39a1f0763e4eb492bee021e4270fce097d3555
   KalturaNetKit: 7c2ce88fb5eb506891f0bf844970ae5306a2fef5
   Log: 5e368c9528db07517d18d2d04ff5fe2b6f5a1e21

--- a/Sources/API/API.swift
+++ b/Sources/API/API.swift
@@ -30,9 +30,6 @@ public protocol DTGContentManager: class {
     /// Stop the content manager, including the playback server.
     func stop()
     
-    /// Resume downloading of items that were in progress when stop() was called.
-    func resumeInterruptedItems() throws
-    
     /// Return all items in the specified state.
     func itemsByState(_ state: DTGItemState) -> [DTGItem]
     
@@ -58,6 +55,18 @@ public protocol DTGContentManager: class {
     /// Start or resume item download.
     /// - Throws: DTGError.itemNotFound
     func startItem(id: String) throws
+    
+    /// Start items download in specified states.
+    /// can be used to resume inProgress (after force quit) / interrupted / paused items, can use multiple selection or just one.
+    ///
+    /// ````
+    /// try startItems(inStates: .inProgress)
+    /// // or like this:
+    /// try startItems(inStates: [.inProgress, .paused])
+    /// ````
+    ///
+    /// - Parameter states: Option set of the states to start.
+    func startItems(inStates states: DTGStartItemStates) throws
     
     /// Pause downloading an item.
     /// - Throws: DTGError.itemNotFound
@@ -125,6 +134,15 @@ public protocol DTGVideoTrack {
     
     /// Bitrate.
     var bitrate: Int { get }
+}
+
+public struct DTGStartItemStates: OptionSet {
+    public let rawValue: Int
+    public init(rawValue: Int) { self.rawValue = rawValue }
+    
+    public static let paused = DTGStartItemStates(rawValue: 1)
+    public static let inProgress = DTGStartItemStates(rawValue: 2)
+    public static let interrupted = DTGStartItemStates(rawValue: 4)
 }
 
 /// Item state.

--- a/Sources/ContentManager/ContentManager.swift
+++ b/Sources/ContentManager/ContentManager.swift
@@ -194,14 +194,26 @@ public class ContentManager: NSObject, DTGContentManager {
         started = false
     }
 
-    public func resumeInterruptedItems() throws {
-        for item in itemsByState(.inProgress) {
-            try startItem(id: item.id)
+    public func startItems(inStates states: DTGStartItemStates) throws {
+        if states.contains(.inProgress) {
+            for item in itemsByState(.inProgress) {
+                try startItem(id: item.id)
+            }
+        }
+        if states.contains(.paused) {
+            for item in itemsByState(.paused) {
+                try startItem(id: item.id)
+            }
+        }
+        if states.contains(.interrupted) {
+            for item in itemsByState(.interrupted) {
+                try startItem(id: item.id)
+            }
         }
     }
 
     public func itemsByState(_ state: DTGItemState) -> [DTGItem] {
-        
+
         return db.items(byState: state)
     }
     
@@ -225,6 +237,8 @@ public class ContentManager: NSObject, DTGContentManager {
     public func loadItemMetadata(id: String, preferredVideoBitrate: Int?, completionHandler: (() -> Void)?) throws {
         
         var item = try findItemOrThrow(id)
+        // can only load metadata on item in `.new` state.
+        guard item.state == .new else { throw DTGError.invalidState(itemId: id) }
         
         let localizer = HLSLocalizer(id: id, url: item.remoteUrl, downloadPath: DTGFilePaths.itemDirUrl(forItemId: id), preferredVideoBitrate: preferredVideoBitrate)
         

--- a/Sources/ContentManager/HLSLocalizer.swift
+++ b/Sources/ContentManager/HLSLocalizer.swift
@@ -22,7 +22,7 @@ struct MockVideoTrack: DTGVideoTrack {
     var bitrate: Int
 }
 
-enum HLSLocalizerError: Error {
+public enum HLSLocalizerError: Error {
     /// sent when an unknown playlist type was encountered
     case unknownPlaylistType
     

--- a/Sources/Downloader/DefaultDownloader.swift
+++ b/Sources/Downloader/DefaultDownloader.swift
@@ -15,7 +15,7 @@ func ==(lhs: DefaultDownloader, rhs: DefaultDownloader) -> Bool {
     return lhs.sessionIdentifier == rhs.sessionIdentifier
 }
 
-enum DownloaderError: Error {
+public enum DownloaderError: Error {
     case downloadAlreadyStarted
     case cannotAddDownloads
     case http(statusCode: Int, rootError: NSError)


### PR DESCRIPTION
* Added startItems(inStates:_) which allows starting items for varying states (paused/interrupted/inProgress)
* Added protection to `loadItemMetadata` to only load metadata for items with `.new` state otherwise throw invalid state error.
* Made error enums public
* Bumped version to 3.0.2