### PR TITLE
Fix pause/resume that was broken in iOS 12

### DIFF
--- a/Sources/DefaultDownloader.swift
+++ b/Sources/DefaultDownloader.swift
@@ -154,6 +154,8 @@ extension DefaultDownloader {
     }
     
     func cancel() {
+        self.blockNewTasks = true
+        
         // Invalidate the session before canceling, so that no new tasks will start
         self.invalidateSession()
         self.cancelDownloadTasks()


### PR DESCRIPTION
In iOS 12+, sometimes `cancel(byProducingResumeData:)` returns an invalid resume
data. The blob returned is very small (around 160 bytes; a valid blob is a few
kbs). The workaround is in two places: when receiving a blob smaller than 200
bytes, don't save it; when loading a blob, if it's smaller than 200 bytes don't
use it. The latter makes sure that if the db is already polluted with bad blobs
we'll still be able to resume.
When there's no resume data, we resume by downloading the chunk again, from scratch.
This is not too bad because chunks are relatively small.

In addition, change `fileprivate` fields to `private` and added some minor safety changes.