### PR TITLE
FEM-2274 DB and session fixes

### DIFF
--- a/Example/DownloadToGo.xcodeproj/xcshareddata/xcschemes/DownloadToGo-Example.xcscheme
+++ b/Example/DownloadToGo.xcodeproj/xcshareddata/xcschemes/DownloadToGo-Example.xcscheme
@@ -34,6 +34,20 @@
                ReferencedContainer = "container:DownloadToGo.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AACDC3C8D5E284825E230D6F4339852F"
+               BuildableName = "DownloadToGo.framework"
+               BlueprintName = "DownloadToGo"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/Example/DownloadToGo.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Example/DownloadToGo.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/Example/DownloadToGo/ViewController.swift
+++ b/Example/DownloadToGo/ViewController.swift
@@ -69,16 +69,15 @@ class ViewController: UIViewController {
     let lam = LocalAssetsManager.managerWithDefaultDataStore()
     
     let items = [
-        Item(id: "bunny", url: "https://noamtamim.com/hls-bunny/index.m3u8"),
-        
-        Item("FPS: Ella 1", id: "1_x14v3p06", partnerId: 1788671),
-        Item("FPS: QA 1", id: "0_4s6xvtx3", partnerId: 4171, env: "http://cdntesting.qa.mkaltura.com"),
-        Item("FPS: QA 2", id: "0_7o8zceol", partnerId: 4171, env: "http://cdntesting.qa.mkaltura.com"),
-        Item("Clear: Kaltura", id: "1_sf5ovm7u", partnerId: 243342),
         Item(id: "QA multi/multi", url: "http://cdntesting.qa.mkaltura.com/p/1091/sp/109100/playManifest/entryId/0_mskmqcit/flavorIds/0_et3i1dux,0_pa4k1rn9/format/applehttp/protocol/http/a.m3u8"),
         Item(id: "Eran multi audio", url: "https://cdnapisec.kaltura.com/p/2035982/sp/203598200/playManifest/entryId/0_7s8q41df/format/applehttp/protocol/https/name/a.m3u8?deliveryProfileId=4712"),
         Item(id: "Trailer", url: "http://cdnbakmi.kaltura.com/p/1758922/sp/175892200/playManifest/entryId/0_ksthpwh8/format/applehttp/tags/ipad/protocol/http/f/a.m3u8"),
         Item(id: "AES-128 multi-key", url: "https://noamtamim.com/random/hls/test-enc-aes/multi.m3u8"),
+        Item(id: "bunny", url: "https://noamtamim.com/hls-bunny/index.m3u8"),
+        Item("FPS: Ella 1", id: "1_x14v3p06", partnerId: 1788671),
+        Item("FPS: QA 1", id: "0_4s6xvtx3", partnerId: 4171, env: "http://cdntesting.qa.mkaltura.com"),
+        Item("FPS: QA 2", id: "0_7o8zceol", partnerId: 4171, env: "http://cdntesting.qa.mkaltura.com"),
+        Item("Clear: Kaltura", id: "1_sf5ovm7u", partnerId: 243342),
     ]
     
     let itemPickerView = UIPickerView()

--- a/Example/DownloadToGo/ViewController.swift
+++ b/Example/DownloadToGo/ViewController.swift
@@ -29,7 +29,7 @@ class Item {
         self.title = id
         self.url = URL(string: url)!
         
-        let source = PKMediaSource.init(id, contentUrl: URL(string: url))
+        let source = PKMediaSource(id, contentUrl: URL(string: url))
         self.entry = PKMediaEntry(id, sources: [source])
         
         self.partnerId = nil
@@ -81,15 +81,9 @@ class ViewController: UIViewController {
         Item(id: "AES-128 multi-key", url: "https://noamtamim.com/random/hls/test-enc-aes/multi.m3u8"),
     ]
     
-    let itemPickerView: UIPickerView = {
-        let picker = UIPickerView()
-        return picker
-    }()
+    let itemPickerView = UIPickerView()
     
-    let languageCodePickerView: UIPickerView = {
-        let picker = UIPickerView()
-        return picker
-    }()
+    let languageCodePickerView = UIPickerView()
     
     var selectedItem: Item! {
         didSet {

--- a/Example/DownloadToGo/ViewController.swift
+++ b/Example/DownloadToGo/ViewController.swift
@@ -69,6 +69,8 @@ class ViewController: UIViewController {
     let lam = LocalAssetsManager.managerWithDefaultDataStore()
     
     let items = [
+        Item(id: "bunny", url: "https://noamtamim.com/hls-bunny/index.m3u8"),
+        
         Item("FPS: Ella 1", id: "1_x14v3p06", partnerId: 1788671),
         Item("FPS: QA 1", id: "0_4s6xvtx3", partnerId: 4171, env: "http://cdntesting.qa.mkaltura.com"),
         Item("FPS: QA 2", id: "0_7o8zceol", partnerId: 4171, env: "http://cdntesting.qa.mkaltura.com"),

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -16,14 +16,3 @@ target 'DownloadToGo_Example' do
     pod 'Nimble', '7.1.3'
   end
 end
-
-#post_install do |installer|
-#    installer.pods_project.targets.each do |target|
-#        target.build_configurations.each do |config|
-#            config.build_settings['ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES'] = 'NO'
-#            if target.name == 'DownloadToGo_Example' || target.name == 'XCGLogger' || target.name == 'PlayKit'
-#                config.build_settings['SWIFT_VERSION'] = '4.0'
-#            end
-#        end
-#    end
-#end

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -8,6 +8,7 @@ target 'DownloadToGo_Example' do
   pod 'PlayKit'	, :path => '../../playkit-ios'
   
   pod 'Toast', '~> 4.0.0'
+  pod 'GCDWebServer', :git => 'https://github.com/noamtamim/GCDWebServer', :branch => 'no-implicit-retain-self'
 
   target 'DownloadToGo_Tests' do
     inherit! :search_paths

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -17,13 +17,13 @@ target 'DownloadToGo_Example' do
   end
 end
 
-post_install do |installer|
-    installer.pods_project.targets.each do |target|
-        target.build_configurations.each do |config|
-            config.build_settings['ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES'] = 'NO'
-            if target.name == 'DownloadToGo_Example' || target.name == 'XCGLogger' || target.name == 'PlayKit'
-                config.build_settings['SWIFT_VERSION'] = '4.0'
-            end
-        end
-    end
-end
+#post_install do |installer|
+#    installer.pods_project.targets.each do |target|
+#        target.build_configurations.each do |config|
+#            config.build_settings['ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES'] = 'NO'
+#            if target.name == 'DownloadToGo_Example' || target.name == 'XCGLogger' || target.name == 'PlayKit'
+#                config.build_settings['SWIFT_VERSION'] = '4.0'
+#            end
+#        end
+#    end
+#end

--- a/Sources/DB/DB.swift
+++ b/Sources/DB/DB.swift
@@ -260,7 +260,7 @@ extension RealmDB {
         try write(rlm) {
             for t in realmTasks {
                 if let et = rlm.object(ofType: DownloadItemTaskRealm.self, forPrimaryKey: t.destinationUrl) {
-                    log.warning("Task with key \(et.destinationUrl) already exists with url=\(et.contentUrl) type=\(et.type)")
+                    log.warning("Task with key \(et.destinationUrl) already exists (item=\(et.dtgItemId) url=\(et.contentUrl) type=\(et.type))")
                 } else {
                     rlm.add(t, update: true)    // Using update so it won't crash if exists
                 }

--- a/Sources/DB/DB.swift
+++ b/Sources/DB/DB.swift
@@ -17,7 +17,7 @@ func getRealm() throws -> Realm {
     return try Realm(configuration: config)
 }
 
-fileprivate func migrateTrackInfoObjects(_ migration: Migration) {
+fileprivate func migrate_to_3(_ migration: Migration) {
     
     // In schema v2, DTGItemRealm had 4 lists of TrackInfoRealm objects:
     // selectedTextTracks, availableTextTracks, selectedAudioTracks, availableAudioTracks
@@ -75,7 +75,7 @@ fileprivate func migrateTrackInfoObjects(_ migration: Migration) {
 
 fileprivate let config = Realm.Configuration(
     fileURL: DTGFilePaths.storagePath.appendingPathComponent("downloadToGo.realm"),
-    schemaVersion: 3,
+    schemaVersion: 4,
     migrationBlock: { migration, oldSchemaVersion in
         
         // We haven’t migrated anything yet, so oldSchemaVersion == 0
@@ -83,13 +83,21 @@ fileprivate let config = Realm.Configuration(
             // The renaming operation should be done outside of calls to `enumerateObjects(ofType: _:)`.
             migration.renameProperty(onType: DownloadItemTaskRealm.className(), from: "trackType", to: "type")
         }
+        
+        // 1 -> 2
         if (oldSchemaVersion < 2) {
             // nothing to do just detect new properties on realm item
         }
         
+        // 2 -> 3
         if (oldSchemaVersion == 2) {    
             // TrackInfo object were only added in schema 2 so this migration is not required if old is 0 or 1
-            migrateTrackInfoObjects(migration)
+            migrate_to_3(migration)
+        }
+        
+        // 3 -> 4
+        if (oldSchemaVersion < 4) {
+            // Primary key for DownloadItemTaskRealm has changed, nothing to do
         }
     },
     objectTypes: [DTGItemRealm.self, DownloadItemTaskRealm.self, TrackInfoRealm.self]
@@ -274,8 +282,9 @@ extension RealmDB {
     
     func removeTask(_ task: DownloadItemTask) throws {
         let rlm = try getRealm()
-        guard let realmTask = rlm.object(ofType: DownloadItemTaskRealm.self, forPrimaryKey: task.contentUrl.absoluteString) else {
-            log.error("No such task \(task.contentUrl)")
+        guard let realmTask = rlm.object(ofType: DownloadItemTaskRealm.self, 
+                                         forPrimaryKey: DownloadItemTaskRealm.relativeDestUrl(task)) else {
+            log.error("No such task \(task.destinationUrl)")
             return
         }
         
@@ -286,9 +295,10 @@ extension RealmDB {
     
     func pauseTasks(_ tasks: [DownloadItemTask]) throws {
         let rlm = try getRealm()
-        try write(rlm) { 
+        try write(rlm) {
             for t in tasks {
-                if let rt = rlm.object(ofType: DownloadItemTaskRealm.self, forPrimaryKey: t.contentUrl.absoluteString) {
+                if let rt = rlm.object(ofType: DownloadItemTaskRealm.self, 
+                                       forPrimaryKey: DownloadItemTaskRealm.relativeDestUrl(t)) {
                     rt.resumeData = t.resumeData
                 }
             }

--- a/Sources/DB/DB.swift
+++ b/Sources/DB/DB.swift
@@ -185,13 +185,16 @@ extension RealmDB {
         }
         
         try write(getRealm()) {
+            if realmItem.isInvalidated {
+                return
+            } 
             realmItem.downloadedSize += incrementDownloadSize
             if let state = state {
                 realmItem.state = state.asString()
             }
         }
         
-        return (realmItem.downloadedSize, realmItem.estimatedSize.value ?? -1)
+        return realmItem.isInvalidated ? (-1, -1) : (realmItem.downloadedSize, realmItem.estimatedSize.value ?? -1)
     }
 
     func removeItem(byId id: String) throws {

--- a/Sources/DB/DB.swift
+++ b/Sources/DB/DB.swift
@@ -258,7 +258,13 @@ extension RealmDB {
         let realmTasks = tasks.map { DownloadItemTaskRealm(object: $0) }
         let rlm = try getRealm()
         try write(rlm) {
-            rlm.add(realmTasks)
+            for t in realmTasks {
+                if let et = rlm.object(ofType: DownloadItemTaskRealm.self, forPrimaryKey: t.destinationUrl) {
+                    log.warning("Task with key \(et.destinationUrl) already exists with url=\(et.contentUrl) type=\(et.type)")
+                } else {
+                    rlm.add(t, update: true)    // Using update so it won't crash if exists
+                }
+            }
         }
     }
     

--- a/Sources/DB/DownloadItemTaskRealm.swift
+++ b/Sources/DB/DownloadItemTaskRealm.swift
@@ -28,7 +28,7 @@ class DownloadItemTaskRealm: Object {
     let order = RealmOptional<Int>()
     
     override static func primaryKey() -> String? {
-        return "contentUrl"
+        return "destinationUrl"
     }
     
     public override class func shouldIncludeInDefaultSchema() -> Bool { return false } 
@@ -38,10 +38,14 @@ class DownloadItemTaskRealm: Object {
         self.dtgItemId = object.dtgItemId
         self.contentUrl = object.contentUrl.absoluteString
         self.type = object.type.asString()
-        self.destinationUrl = String(object.destinationUrl.absoluteString[DTGFilePaths.storagePath.absoluteString.endIndex...])
+        self.destinationUrl = DownloadItemTaskRealm.relativeDestUrl(object)
         self.resumeData = object.resumeData
         self.order.value = object.order
     }
+    
+    static func relativeDestUrl(_ obj: DownloadItemTask) -> String {
+        return String(obj.destinationUrl.absoluteString[DTGFilePaths.storagePath.absoluteString.endIndex...])
+    } 
     
     func asObject() -> DownloadItemTask {
         let contentUrl = URL(string: self.contentUrl)!


### PR DESCRIPTION
The previous primary key was the content URL. This is not good enough because there may be conflicts. The new primary key is the destination path.
Before adding a task check if a task with the same id exists.

In addition improved session handling in DefaultDownloader.