### PR TITLE
FEM-2811: Use redirected master URL as base for chunks url

### DIFF
--- a/Example/DownloadToGo/ViewController.swift
+++ b/Example/DownloadToGo/ViewController.swift
@@ -558,7 +558,9 @@ extension ViewController {
 extension ViewController: ContentManagerDelegate {
     
     func item(id: String, didDownloadData totalBytesDownloaded: Int64, totalBytesEstimated: Int64?) {
-        if let totalBytesEstimated = totalBytesEstimated, id == self.selectedItem.id {
+        if id != selectedItem.id {return}   // only update the view for selected item.
+        
+        if let totalBytesEstimated = totalBytesEstimated {
             if totalBytesEstimated > totalBytesDownloaded {
                 DispatchQueue.main.async {
                     self.progressView.progress = Float(totalBytesDownloaded) / Float(totalBytesEstimated)


### PR DESCRIPTION
syncHttpGetUtf8String() returns the final response URL and it's used as the base url for loading media playlist.

Fixes FEM-2811.