### PR TITLE
FEC-9983: Workaround for M3U8Kit bug of handling `\r\n`

### DIFF
--- a/Sources/HLSLocalizerUtils.swift
+++ b/Sources/HLSLocalizerUtils.swift
@@ -93,7 +93,11 @@ struct VideoTrack: DTGVideoTrack {
 func loadMasterPlaylist(url: URL) throws -> M3U8MasterPlaylist {
     let (text, finalURL) = try syncHttpGetUtf8String(url: url)
     
-    if let playlist = M3U8MasterPlaylist(content: text, baseURL: finalURL.deletingLastPathComponent()) {
+    // The parser has an issue with \r in master playlists - as a workaround,
+    // replace "\r\n" and "\r" to "\n" before sending the text to the parser.
+    let cleanText = text.replacingOccurrences(of: "\r\n", with: "\n").replacingOccurrences(of: "\r", with: "\n")
+        
+    if let playlist = M3U8MasterPlaylist(content: cleanText, baseURL: finalURL.deletingLastPathComponent()) {
         return playlist
     } else {
         throw HLSLocalizerError.malformedPlaylist

--- a/Sources/HLSLocalizerUtils.swift
+++ b/Sources/HLSLocalizerUtils.swift
@@ -265,14 +265,6 @@ extension String {
     func m3u8Attribs(prefix: String) -> [String:String]? {
         return parseM3U8Attributes(self, prefix)
     }
-
-    func replacing(playlistUrl: URL?, type: DownloadItemTaskType) -> String {
-        if let url = playlistUrl {
-            return self.replacingOccurrences(of: url.absoluteString, with: url.mediaPlaylistRelativeLocalPath(as: type))
-        } else {
-            return self
-        }
-    }
 }
 
 extension URL {
@@ -282,19 +274,6 @@ extension URL {
     
     func segmentRelativeLocalPath() -> String {
         return "\(absoluteString.md5()).\(pathExtension)"
-    }
-}
-
-extension NSMutableString {
-    func replace(playlistUrl: URL?, type: DownloadItemTaskType) {
-        if let url = playlistUrl {
-            self.replaceOccurrences(of: url.absoluteString, with: url.mediaPlaylistRelativeLocalPath(as: type), options: [], range: NSMakeRange(0, self.length))
-        }
-    }
-    
-    func replace(segmentUrl: String, relativeTo: URL) throws {
-        guard let relativeLocalPath = URL(string: segmentUrl, relativeTo: relativeTo)?.segmentRelativeLocalPath() else { throw HLSLocalizerError.invalidState }
-        self.replaceOccurrences(of: segmentUrl, with: relativeLocalPath, options: [], range: NSMakeRange(0, self.length))
     }
 }
 


### PR DESCRIPTION
This is a temporary workaround, until the issue is fixed in M3U8Kit/M3U8Parser#24.
