### PR TITLE
Fixed dev version suffix

### DIFF
--- a/DownloadToGo.podspec
+++ b/DownloadToGo.podspec
@@ -1,4 +1,4 @@
-suffix = '-dev'   # Dev mode
+suffix = '.0000'   # Dev mode
 # suffix = ''       # Release
 
 Pod::Spec.new do |s|


### PR DESCRIPTION
Fixed dev version suffix from '-dev' to '.0000'  so that Cocoapods won't fail when there are dependencies between them.