### PR TITLE
FEC-11074 App crashes (Realm) upon downloading several items in parallel.

### DIFF
--- a/DownloadToGo.podspec
+++ b/DownloadToGo.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'M3U8Kit', '1.0.0'
   s.dependency 'GCDWebServer', '~> 3.5.4'
-  s.dependency 'RealmSwift', '~> 10.6.0'
+  s.dependency 'RealmSwift', '~> 10.7.2'
   s.dependency 'XCGLogger', '~> 7.0.0'
   s.dependency 'PlayKitUtils', '~> 0.5'
 end


### PR DESCRIPTION
Updating RealmSwift to v 10.7.2

Solves FEC-11074