### PR TITLE
FEC-11607 Fix deprecated class in Realm

### DIFF
--- a/Example/DownloadToGo/ViewController.swift
+++ b/Example/DownloadToGo/ViewController.swift
@@ -164,10 +164,11 @@ class ViewController: UIViewController {
         
         items = loadedItems.map{Item(json: $0)}
         
-        let completedItems = try! self.cm.itemsByState(.completed)
-        for (index, item) in completedItems.enumerated() {
-            if item.id.hasPrefix("test") && item.id.hasSuffix("()") {
-                self.items.insert(Item(item.id, id: item.id, url: "file://foo.bar/baz"), at: index)
+        if let completedItems = try? self.cm.itemsByState(.completed) {
+            for (index, item) in completedItems.enumerated() {
+                if item.id.hasPrefix("test") && item.id.hasSuffix("()") {
+                    self.items.insert(Item(item.id, id: item.id, url: "file://foo.bar/baz"), at: index)
+                }
             }
         }
 

--- a/Sources/DB/DTGItemRealm.swift
+++ b/Sources/DB/DTGItemRealm.swift
@@ -49,13 +49,13 @@ class DTGItemRealm: Object {
     /// The item's current state.
     @objc dynamic var state: String = ""
     /// Estimated size of the item.
-    var estimatedSize = RealmOptional<Int64>()
+    var estimatedSize = RealmProperty<Optional<Int64>>()
     /// Downloaded size in bytes.
     @objc dynamic var downloadedSize: Int64 = 0
     
-    var duration = RealmOptional<TimeInterval>()
-    var totalTaskCount = RealmOptional<Int64>()
-    var completedTaskCount = RealmOptional<Int64>()
+    var duration = RealmProperty<Optional<TimeInterval>>()
+    var totalTaskCount = RealmProperty<Optional<Int64>>()
+    var completedTaskCount = RealmProperty<Optional<Int64>>()
 
     let textTracks = List<TrackInfoRealm>()
     let audioTracks = List<TrackInfoRealm>()

--- a/Sources/DB/DownloadItemTaskRealm.swift
+++ b/Sources/DB/DownloadItemTaskRealm.swift
@@ -25,7 +25,7 @@ class DownloadItemTaskRealm: Object {
     
     @objc dynamic var resumeData: Data? = nil
     
-    let order = RealmOptional<Int>()
+    let order = RealmProperty<Optional<Int>>()
     
     override static func primaryKey() -> String? {
         return "destinationUrl"


### PR DESCRIPTION
Updated deprecated RealmOptional class to RealmProperty class.
This way of change, no migration is needed.

Solves FEC-11607

Added a fix in sample for crash upon using '!'.