### PR TITLE
DTGSelectionOptions super.description added to description

### DIFF
--- a/Sources/HLSLocalizerUtils.swift
+++ b/Sources/HLSLocalizerUtils.swift
@@ -276,7 +276,8 @@ extension URL {
 extension DTGSelectionOptions {
     
     public override var description: String {
-        return """
+        return super.description + "\n" +
+        """
         Video: height=\(videoHeight ?? -1) width=\(videoWidth ?? -1)
         Video codecs=\(videoCodecs ?? []) bitrates=\(videoBitrates)
         Audio codecs=\(audioCodecs ?? [])


### PR DESCRIPTION
DTGSelectionOptions super.description added to description, this was missing in FEC-11688
Nothing critical, just for convenience use.